### PR TITLE
fix bug: 修正指定交易日切换小时与分钟的写法

### DIFF
--- a/shinny_calendar/__init__.py
+++ b/shinny_calendar/__init__.py
@@ -89,8 +89,8 @@ class CalendarUtility:
         return _trading_day(
             dt or self.now(),
             self.holidays,
-            change_trading_day_hour or self.change_trading_day_hour,
-            change_trading_day_minute or self.change_trading_day_minute
+            change_trading_day_hour if change_trading_day_hour is not None else self.change_trading_day_hour,
+            change_trading_day_minute if change_trading_day_minute is not None else self.change_trading_day_minute
         )
 
     def today(self) -> datetime.date:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 改进了交易日期计算方法中参数处理的逻辑，确保零值被正确处理，避免意外的默认值分配。
	- 增强了 `trading_day` 方法的参数处理准确性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->